### PR TITLE
Implement: `refinement` type check

### DIFF
--- a/lib/rdl/boot.rb
+++ b/lib/rdl/boot.rb
@@ -11,6 +11,7 @@ def RDL.config
   yield(RDL::Config.instance)
 end
 require 'rdl/info.rb'
+require 'rdl/refinement_set.rb'
 
 module RDL::Globals
   # Method/variable info table with kinds:

--- a/lib/rdl/refinement_set.rb
+++ b/lib/rdl/refinement_set.rb
@@ -1,0 +1,24 @@
+class RDL::RefinementSet
+  @@refinement_connections = {}
+  @@refinements = {}
+
+  def self.using(ref, refinement_module)
+    (@@refinement_connections[ref.to_s] ||= [])<< refinement_module
+  end
+
+  def self.usings_modules(ref)
+    @@refinement_connections[ref]
+  end
+
+  def self.add(ref, klass, meth, processed_type)
+    klass = klass.to_s
+    @@refinements[ref] ||= {}
+    @@refinements[ref][klass] ||= {}
+    @@refinements[ref][klass][meth] ||= []
+    @@refinements[ref][klass][meth]<< processed_type
+  end
+
+  def self.get(ref, klass, name)
+    @@refinements.fetch(ref, {}).fetch(klass, {}).fetch(name, nil)
+  end
+end

--- a/test/test_refinement.rb
+++ b/test/test_refinement.rb
@@ -1,0 +1,45 @@
+require 'minitest/autorun'
+$LOAD_PATH << File.dirname(__FILE__) + "/../lib"
+require 'rdl'
+
+class TestRefinement < Minitest::Test
+  include RDL::Type
+  include RDL::Contract
+  extend RDL::Annotate
+
+  module TestModule
+    refine Array do
+      extend RDL::Annotate
+      refine_type :foo, '(Boolean) -> Boolean', typecheck: :later
+      def foo(v)
+        v.to_s
+      end
+    end
+  end
+  RDL.using_type self, TestModule
+
+  def test_uging_type
+    before_count = RDL::RefinementSet.class_variable_get(:@@refinement_connections).size
+    RDL.using_type self, TestModule
+    after_count = RDL::RefinementSet.class_variable_get(:@@refinement_connections).size
+    assert before_count == after_count - 1
+  end
+
+  using TestModule
+
+  class Test
+    extend RDL::Annotate
+
+    type '() -> String', typecheck: :later
+    def test
+      [].foo("1")
+    end
+  end
+
+  def test_refine_type
+    assert_raises RDL::Typecheck::StaticTypeError do
+      Test.new.test
+      RDL.do_typecheck :later
+    end
+  end
+end


### PR DESCRIPTION
I evaluate RDL now and I notice that some functions lack yet.
so, I try to implement Refinement, because I wanto to use it.

I use like below code.

```ruby
module ArrayExtention
 refine do
   extend RDL::Annotate
   refine_type '()->String'
   def foo
     [].to_s
   end
 end
end
using_type ArrayExtention
```

I declare `refine_type` and `using_type` method.
It is nessesary now.

I'm writing README.md now.

I expect some function (for exmple method_missing) will support in future.
