### PR TITLE
Add test showing that finite hashes are subtypes of generic hashes of the right shape

### DIFF
--- a/test/test_le.rb
+++ b/test/test_le.rb
@@ -318,6 +318,13 @@ class TestLe < Minitest::Test
     assert tt("Integer") <= tt("!Object")
   end
 
+  def test_finite_hash_to_hash
+    assert tt("{a: Integer, b: String}") <= tt("Hash<Symbol,Integer or String>")
+    # Should these be true?
+    # assert tt("{a: Integer, b: String}") <= tt("Hash")
+    # assert tt("{a: Integer, b: String}") <= tt("Hash<Symbol,%any>")
+  end
+
   # def test_intersection
   #   skip "<= not defined on intersection"
   #   tobject_and_basicobject = IntersectionType.new(RDL::Globals.types[:object], @tbasicobject)


### PR DESCRIPTION
I was exploring the subtype relationships between finite hashes and generic hashes and was surprised by the two commented out results here. Should they be true? Or can you please explain to me why they aren't.