### PR TITLE
Fix wrap class

### DIFF
--- a/lib/rdl/util.rb
+++ b/lib/rdl/util.rb
@@ -66,7 +66,7 @@ class RDL::Util
       return false
     end
     klass_str = RDL::Util.to_class_str(klass).hash
-    if mstr.start_with?('__rdl') and mstr.end_with?('_old_#{klass_str}')
+    if mstr.start_with?('__rdl') and mstr.end_with?("_old_#{klass_str}")
       mstr0 = RDL::Wrap.unwrapped_name(klass, mstr)
       owner0 = sk.instance_method(mstr0).owner
       owner = sk.instance_method(mstr).owner

--- a/lib/rdl/wrap.rb
+++ b/lib/rdl/wrap.rb
@@ -151,12 +151,12 @@ RUBY
     "__rdl_#{meth.to_s}_old_#{klass_str}".to_sym
   end
 
-  def self.unwrapped_name(s)
+  def self.unwrapped_name(klass, s)
     if not s.start_with?('__rdl_') and s.include?('_old_')
       raise Exception, "cannot get unwrapped name for #{s}"
     end
     klass_str = RDL::Util.to_class_str(klass).hash.to_s
-    s = klass_str.split("_#{klass_str}")
+    s = s.split("_#{klass_str}")[0]
     s[6..-5]
   end
 


### PR DESCRIPTION
I was trying to fix a test spew about an unused variable and stumbled upon this string interpolation using a `'`.  I think this repo would benefit from rubocop being used to catch classes of bugs like this.

I'm not sure what this affects but I made the code into a shape that I think it was intended.