### PR TITLE
Allow untyped methods to be called from typed methods

### DIFF
--- a/lib/rdl/typecheck.rb
+++ b/lib/rdl/typecheck.rb
@@ -1510,7 +1510,8 @@ RUBY
     # arity right.
     method = begin
       the_klass.instance_method(name)
-    rescue NameError
+    rescue NameError => e
+      puts "Unknown method: #{the_klass}.#{name}"
       nil
     end
 
@@ -1526,7 +1527,7 @@ RUBY
         args << RDL::Type::VarargType.new(RDL::Globals.types[:top])
       end
     else
-      args = []
+      args = [RDL::Type::VarargType.new(RDL::Globals.types[:top])]
     end
 
     ret = RDL::Globals.types[:bot]

--- a/lib/rdl/typecheck.rb
+++ b/lib/rdl/typecheck.rb
@@ -1505,7 +1505,36 @@ RUBY
         error :missing_ancestor_type, [ancestor, klass, name], e
       end
     }
-    return nil
+
+    # No types writen out, without full fledged inference, lets simply get the
+    # arity right.
+    method = begin
+      the_klass.instance_method(name)
+    rescue NameError
+      nil
+    end
+
+    if method
+      arity = method.arity
+      has_varargs = false
+      if arity < 0
+        has_varargs = true
+        arity = -arity - 1
+      end
+      args = arity.times.map {RDL::Globals.types[:top]}
+      if has_varargs
+        args << RDL::Type::VarargType.new(RDL::Globals.types[:top])
+      end
+    else
+      args = []
+    end
+
+    ret = RDL::Globals.types[:bot]
+    if name == :initialize
+      ret = RDL::Type::NominalType.new(the_klass)
+    end
+
+    return [RDL::Type::MethodType.new(args, nil, ret)]
   end
 end
 

--- a/test/test_typecheck.rb
+++ b/test/test_typecheck.rb
@@ -1685,4 +1685,19 @@ class TestTypecheck < Minitest::Test
 
     assert_nil TestTypecheck::A5.new.foo(:a)
   end
+
+  def test_untyped_vararg
+    self.class.class_eval "module UntypedVararg; end"
+    UntypedVararg.class_eval do
+      extend RDL::Annotate
+      type '(Integer) -> String', :typecheck => :call
+      def self.foo(x)
+        sprintf("%d", bar)
+      end
+      # untyped, so it returns the bottom type
+      def self.bar; 1; end
+    end
+
+    assert_equal "1", UntypedVararg.foo(1)
+  end
 end

--- a/test/test_typecheck.rb
+++ b/test/test_typecheck.rb
@@ -1700,4 +1700,21 @@ class TestTypecheck < Minitest::Test
 
     assert_equal "1", UntypedVararg.foo(1)
   end
+
+  def test_unknown_method
+    self.class.class_eval "module UnknownMethod; end"
+    UnknownMethod.class_eval do
+      extend RDL::Annotate
+      type '() -> nil', :typecheck => :call
+      def self.foo
+        begin
+          whatever(5, 4)
+        rescue
+          nil
+        end
+      end
+    end
+
+    assert_nil UnknownMethod.foo
+  end
 end


### PR DESCRIPTION
I'm sure this one will be contentious so I didn't go through and fix all the failing tests before discussing. It solves the problem I raised in https://github.com/plum-umd/rdl/issues/37 .

We need a way to migrate code into RDL and forcing it all to be atomic won't work for our multi-million line codebase. This is the same solution we used for Hack when migrating (we used an any type that is the union of (top and bottom) but I'm not sure why). In this PR I used the top type for parameters and the bottom type for return types. I assume we'll have to do something for blocks as well, but I haven't run into that just yet.