### PR TITLE
[issue] show to_proc bug

### DIFF
--- a/test/test_typecheck.rb
+++ b/test/test_typecheck.rb
@@ -1685,4 +1685,22 @@ class TestTypecheck < Minitest::Test
 
     assert_nil TestTypecheck::A5.new.foo(:a)
   end
+
+  def test_to_proc
+    self.class.class_eval "class ToProc; end"
+    ToProc.class_eval do
+      extend RDL::Annotate
+      type '() -> Array<Integer>', :typecheck => :call
+      def self.foo
+        a = [self.new].map{|x| x.bar}
+        b = [self.new].map(&:bar)
+      end
+      type '() -> Integer', :typecheck => :call
+      def bar
+        5
+      end
+    end
+
+    assert_equal [5], ToProc.foo
+  end
 end


### PR DESCRIPTION
I don't know how to fix this one. I tried but the handling of `:to_proc` wasn't making sense to me. It seems to be trying to resolve `bar` based on the scoping immediately instead of later when it is called, and the shape of the call seemed to not know about how it was being called.

The assignment to `a` and the assignment to `b` should be typechecked the same way. `a` succeed and `b` fails with

```

  1) Error:
TestTypecheck#test_to_proc:
RDL::Typecheck::StaticTypeError:
/Users/pt/stripe/rdl/test/test_typecheck.rb:1666:28: error: block argument has type `() -> Integer' but expecting type `(TestTypecheck::ToProc) -> u'
/Users/pt/stripe/rdl/test/test_typecheck.rb:1666:         b = [self.new].map(&:bar)
/Users/pt/stripe/rdl/test/test_typecheck.rb:1666:                            ^~~~~
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:158:in `error'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1441:in `tc_block'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1298:in `block (2 levels) in tc_send_one_recv'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1294:in `each'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1294:in `block in tc_send_one_recv'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1291:in `each'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1291:in `tc_send_one_recv'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1214:in `block in tc_send'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1213:in `each'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:1213:in `tc_send'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:678:in `block in tc'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:140:in `scope_merge'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:655:in `tc'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:476:in `tc'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:913:in `block in tc'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:913:in `each'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:913:in `tc'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:247:in `block in typecheck'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:226:in `each'
    /Users/pt/stripe/rdl/lib/rdl/typecheck.rb:226:in `typecheck'
    /Users/pt/stripe/rdl/lib/rdl/wrap.rb:57:in `block in foo'
    /Users/pt/stripe/rdl/lib/rdl/switch.rb:13:in `off'
    /Users/pt/stripe/rdl/lib/rdl/wrap.rb:48:in `foo'
    /Users/pt/stripe/rdl/test/test_typecheck.rb:1674:in `test_to_proc'
```