### PR TITLE
invent %dynamic

### DIFF
--- a/lib/rdl/boot.rb
+++ b/lib/rdl/boot.rb
@@ -84,6 +84,7 @@ require 'rdl/types/annotated_arg.rb'
 require 'rdl/types/bot.rb'
 require 'rdl/types/dependent_arg.rb'
 require 'rdl/types/dots_query.rb'
+require 'rdl/types/dynamic.rb'
 require 'rdl/types/finite_hash.rb'
 require 'rdl/types/generic.rb'
 require 'rdl/types/intersection.rb'
@@ -149,6 +150,7 @@ module RDL::Globals
   @types[:regexp] = RDL::Type::NominalType.new Regexp
   @types[:standard_error] = RDL::Type::NominalType.new StandardError
   @types[:proc] = RDL::Type::NominalType.new Proc
+  @types[:dynamic] = RDL::Type::DynamicType.new
 
   # Hash from special type names to their values
   @special_types = {'%any' => @types[:top],

--- a/lib/rdl/types/dynamic.rb
+++ b/lib/rdl/types/dynamic.rb
@@ -1,0 +1,52 @@
+module RDL::Type
+  class DynamicType < Type
+    @@cache = nil
+
+    class << self
+      alias :__new__ :new
+    end
+
+    def self.new
+      @@cache = DynamicType.__new__ unless @@cache
+      return @@cache
+    end
+
+    def initialize
+      super
+    end
+
+    def to_s
+      "%dynamic"
+    end
+
+    def ==(other)
+      other.instance_of? DynamicType
+    end
+
+    alias eql? ==
+
+    def match(other)
+      other = other.canonical
+      other = other.type if other.instance_of? AnnotatedArgType
+      return true if other.instance_of? WildQuery
+      return self == other
+    end
+
+    def <=(other)
+      return Type.leq(self, other)
+    end
+
+    def member?(obj, *args)
+      # There are no values of this type
+      false
+    end
+
+    def instantiate(inst)
+      return self
+    end
+
+    def hash
+      91
+    end
+  end
+end

--- a/lib/rdl/types/type.rb
+++ b/lib/rdl/types/type.rb
@@ -49,6 +49,10 @@ module RDL::Type
       return true if left.is_a? BotType
       return true if right.is_a? TopType
 
+      # dyanmic, anything goes
+      return true if left.is_a? DynamicType
+      return true if right.is_a? DynamicType
+
       # type variables
       begin inst.merge!(left.name => right); return true end if inst && ileft && left.is_a?(VarType)
       begin inst.merge!(right.name => left); return true end if inst && !ileft && right.is_a?(VarType)


### PR DESCRIPTION
I think this is a better alternative to https://github.com/plum-umd/rdl/pull/48 . It is done in a similar way except it doesn't return a `%bot`, instead a new type called `%dynamic` is returned which is infectious and allows anything to be done to it.

For migration we'll want a way to annotate that your function (or class or file) can't have any `%dynamic`.