### PR TITLE
[issue] Shows bug with empty tuple promotion

### DIFF
--- a/test/test_typecheck.rb
+++ b/test/test_typecheck.rb
@@ -1685,4 +1685,22 @@ class TestTypecheck < Minitest::Test
 
     assert_nil TestTypecheck::A5.new.foo(:a)
   end
+
+  def test_tuple_promote
+    self.class.class_eval "module TuplePromote; end"
+    TuplePromote.class_eval do
+      extend RDL::Annotate
+
+      type '() ->  nil', :typecheck => :call
+      def self.foo
+        a = []
+        a.each do |v|
+          v.to_s
+        end
+        nil
+      end
+    end
+
+    assert_nil TuplePromote.foo
+  end
 end


### PR DESCRIPTION
We ran into this bug in production and I'm not too sure how to fix it. The `:send` promotes the `[]` to `Array<%bot>` and then iterates over the `%bot`, but in this case it would never enter the block so it should just skip over checking it with an empty tuple. (Our case was obviously more complex but I boiled it down here)