### PR TITLE
Add Marshal.dump

### DIFF
--- a/lib/types/core/marshal.rb
+++ b/lib/types/core/marshal.rb
@@ -1,3 +1,6 @@
 RDL.nowrap :Marshal
 
 RDL.type :Marshal, 'self.load', '(String, ?Proc) -> Object'
+
+RDL.type :Marshal, 'self.dump', '(Object, ?IO, ?Integer) -> Object'
+RDL.type :Marshal, 'self.dump', '(Object, ?Integer) -> Object'


### PR DESCRIPTION
The docs type this as `dump( obj [, anIO], limit=-1)`, and source
confirms that it effectively has an optional *middle* argument.