### PR TITLE
fix aliases

### DIFF
--- a/lib/types/core/dir.rb
+++ b/lib/types/core/dir.rb
@@ -1,6 +1,6 @@
 RDL.nowrap :Dir
 
-RDL.rdl_alias :Dir, :[], :glob
+RDL.rdl_alias :Dir, :'self.[]', :'self.glob'
 
 RDL.type :Dir, 'self.chdir', '(?(String or Pathname)) -> 0'
 RDL.type :Dir, 'self.chdir', '(?(String or Pathname)) { (String) -> u } -> u'

--- a/lib/types/core/file.rb
+++ b/lib/types/core/file.rb
@@ -23,7 +23,7 @@ RDL.type :File, 'self.expand_path', '(%path file, ?%path dir) -> String abs_file
 RDL.type :File, 'self.extname', '(String path) -> String'
 RDL.type :File, 'self.file?', '(String or IO file) -> %bool'
 RDL.type :File, 'self.fnmatch', '(String pattern, String path, ?Integer flags) -> %bool'
-RDL.rdl_alias :File, :fnmatch?, :fnmatch
+RDL.rdl_alias :File, :'self.fnmatch?', :'self.fnmatch'
 RDL.type :File, 'self.ftype', '(String file) -> String' # TODO: return in set of strings
 RDL.type :File, 'self.grpowned?', '(String or IO file) -> %bool'
 RDL.type :File, 'self.identical?', '(String or IO file_1, String or IO file_2) -> %bool'
@@ -56,7 +56,7 @@ RDL.type :File, 'self.symlink', '(String old, String new) -> 0'
 RDL.type :File, 'self.symlink?', '(String file) -> %bool'
 RDL.type :File, 'self.truncate', '(String file, Integer) -> 0'
 RDL.type :File, 'self.umask', '(?Integer) -> Integer'
-RDL.rdl_alias :File, :unlink, :delete
+RDL.rdl_alias :File, :'self.unlink', :'self.delete'
 RDL.type :File, 'self.utime', '(Time atime, Time mtime, *String files) -> Integer'
 RDL.type :File, 'self.world_readable?', '(String or IO file) -> Integer or nil'
 RDL.type :File, 'self.world_writable?', '(String or IO file) -> Integer or nil'

--- a/lib/types/core/io.rb
+++ b/lib/types/core/io.rb
@@ -62,7 +62,7 @@ RDL.type :IO, :ioctl, '(Integer integer_cmd, String or Integer arg) -> Integer'
 RDL.type :IO, :isatty, '() -> %bool'
 RDL.type :IO, :lineno, '() -> Integer'
 RDL.type :IO, :lineno=, '(Integer) -> Integer'
-RDL.rdl_alias :IO, :lines, :each_line # deprecated
+RDL.rdl_alias :IO, :lines, :each # deprecated
 RDL.type :IO, :pid, '() -> Integer'
 RDL.type :IO, :pos, '() -> Integer'
 RDL.type :IO, :pos=, '(Integer) -> Integer'

--- a/lib/types/core/kernel.rb
+++ b/lib/types/core/kernel.rb
@@ -71,7 +71,7 @@ RDL.type :Kernel, 'self.select',
 # RDL.type :Kernel, 'self.set_trace_func' #TODO
 RDL.type :Kernel, 'self.sleep', '(Numeric duration) -> Integer'
 # RDL.type :Kernel, 'self.spawn' #TODO
-RDL.rdl_alias :Kernel, :sprintf, :format # TODO: are they aliases?
+RDL.rdl_alias :Kernel, :'self.sprintf', :'self.format' # TODO: are they aliases?
 RDL.type :Kernel, 'self.srand', '(Numeric number) -> Numeric'
 RDL.type :Kernel, 'self.syscall', '(Integer num, *%any args) -> %any' # TODO : ?
 # RDL.type :Kernel, 'self.system' # TODO

--- a/lib/types/core/process.rb
+++ b/lib/types/core/process.rb
@@ -86,7 +86,6 @@ RDL.nowrap :'Process::Status'
  RDL.type :'Process::Status', :success?, '() -> %bool'
  RDL.type :'Process::Status', :termsig, '() -> Integer or nil'
  RDL.type :'Process::Status', :to_i, '() -> Integer'
-RDL.rdl_alias :'Process::Status', :to_int, :to_i
 RDL.type :'Process::Status', :to_s, '() -> String'
 
 RDL.nowrap :'Process::Sys'

--- a/lib/types/core/range.rb
+++ b/lib/types/core/range.rb
@@ -26,7 +26,7 @@ RDL.type :Range, :max, '() -> t'
 RDL.type :Range, :max, '() { (t, t) -> Integer } -> t'
 RDL.type :Range, :max, '(Integer n) -> Array<t>'
 RDL.type :Range, :max, '(Integer n) { (t, t) -> Integer } -> Array<t>'
-RDL.rdl_alias :Range, :member?, :include
+RDL.rdl_alias :Range, :member?, :include?
 RDL.type :Range, :min, '() -> t'
 RDL.type :Range, :min, '() { (t, t) -> Integer } -> t'
 RDL.type :Range, :min, '(Integer n) -> Array<t>'

--- a/lib/types/core/regexp.rb
+++ b/lib/types/core/regexp.rb
@@ -5,8 +5,8 @@ RDL.type :Regexp, 'self.last_match', '() -> MatchData', wrap: false # Can't wrap
 RDL.type :Regexp, 'self.last_match', '(Integer) -> String', wrap: false
 RDL.type :Regexp, :initialize, '(String, ?%any options, ?String kcode) -> self'
 RDL.type :Regexp, :initialize, '(Regexp) -> self'
-RDL.rdl_alias :Regexp, 'self.compile', 'self.new'
-RDL.rdl_alias :Regexp, 'self.quote', 'self.escape'
+RDL.rdl_alias :Regexp, :'self.compile', :initialize
+RDL.rdl_alias :Regexp, :'self.quote', :'self.escape'
 RDL.type :Regexp, 'self.try_convert', '(%any obj) -> Regexp or nil'
 RDL.type :Regexp, 'self.union', '(*(Regexp or String) pats) -> Regexp'
 RDL.type :Regexp, 'self.union', '(Array<Regexp or String> pats) -> Regexp'

--- a/lib/types/core/set.rb
+++ b/lib/types/core/set.rb
@@ -18,7 +18,7 @@ RDL.type :Set, :add, '(t o) -> self'
 RDL.type :Set, :add?, '(t o) -> self or nil'
 RDL.type :Set, :classify, '() { (u) -> t } -> Hash<u, Set<t>>'
 RDL.type :Set, :clear, '() -> self'
-RDL.rdl_alias :Set, :collect!, :map
+RDL.rdl_alias :Set, :collect!, :map!
 RDL.type :Set, :delete, '(t o) -> self'
 RDL.type :Set, :delete?, '(t o) -> self or nil'
 RDL.type :Set, :delete_if, '() { (t) -> %bool } -> self'


### PR DESCRIPTION
Many of the alias definitions were wrong. When analyzing against the 2.4 runtime I found these incorrect ones. They are also pretty inconsistent between symbols and strings but I didn't go attack that.