### PR TITLE
Fix a typo of "No type parameters defined.." error

### DIFF
--- a/lib/rdl/types/type.rb
+++ b/lib/rdl/types/type.rb
@@ -98,7 +98,7 @@ module RDL::Type
         # do check here to avoid hiding errors if generic type written
         # with wrong number of parameters but never checked against
         # instantiated instances
-        raise TypeError, "No type parameters defined for #{base.name}" unless formals
+        raise TypeError, "No type parameters defined for #{left.base.name}" unless formals
         return false unless left.base == right.base
         return variance.zip(left.params, right.params).all? { |v, tl, tr|
           case v


### PR DESCRIPTION
```
require "rdl"
extend RDL::Annotate

type "(Array<Integer>) -> Float"
def foo(x)
end

type "() -> %any", typecheck: :now
def bar
  foo([1, 2, 3])
end
```

Produces:

```
Traceback (most recent call last):
	21: from t.rb:9:in `<main>'

*snip*

	 1: from /home/mame/work/rdl/lib/rdl/types/type.rb:172:in `leq'
/home/mame/work/rdl/lib/rdl/types/type.rb:101:in `leq': undefined local variable or method `base' for RDL::Type::Type:Class (NameError)
```