### PR TITLE
Add parens to make the test work on Ruby 2.5.0

### DIFF
--- a/test/test_generic.rb
+++ b/test/test_generic.rb
@@ -28,7 +28,7 @@ class TestGeneric < Minitest::Test
   class B
     extend RDL::Annotate
     # class for checking other variance annotations
-    type_params [:a, :b], nil, variance: [:+, :-] { |a, b| true }
+    type_params([:a, :b], nil, variance: [:+, :-]) { |a, b| true }
     type "(a) -> nil"
     def m1(x)
       nil


### PR DESCRIPTION
Ruby 2.5.0 prohibits no-paren method calls with brace block.
(The syntax had been unintentionally accepted until 2.4.)