### PR TITLE
Support multiple-value return (e.g., return 1, 2)

### DIFF
--- a/lib/rdl/typecheck.rb
+++ b/lib/rdl/typecheck.rb
@@ -900,10 +900,13 @@ RUBY
       [env, RDL::Globals.types[:bot]]
     when :return
       # TODO return in lambda returns from lambda and not outer scope
-      if e.children[0]
-         env1, t1 = tc(scope, env, e.children[0])
+      case e.children.size
+      when 0
+        env1, t1 = [env, RDL::Globals.types[:nil]]
+      when 1
+        env1, t1 = tc(scope, env, e.children[0])
       else
-         env1, t1 = [env, RDL::Globals.types[:nil]]
+        env1, t1 = tc(scope, env, AST::Node.new(:array, e.children))
       end
       error :bad_return_type, [t1.to_s, scope[:tret]], e unless t1 <= scope[:tret]
       [env1, RDL::Globals.types[:bot]] # return is a void value expression


### PR DESCRIPTION
This PR fixes the following error:

```ruby
require "rdl"

extend RDL::Annotate

type "() -> [Integer, Integer]", typecheck: :now
def foo
  return 1, 2
end
```

```
/home/mame/local/lib/ruby/gems/2.5.0/gems/rdl-2.1.0/lib/rdl/typecheck.rb:158:in `error':  (RDL::Typecheck::StaticTypeError)
t.rb:7:3: error: got type `1' where return type `[Integer, Integer]' expected
t.rb:7:   return 1, 2
t.rb:7:   ^~~~~~~~~~~
```