### PR TITLE
Fix a typo by replacing `class` with `klass`

### DIFF
--- a/lib/rdl/typecheck.rb
+++ b/lib/rdl/typecheck.rb
@@ -620,7 +620,7 @@ module RDL::Typecheck
           if env[:self].is_a?(RDL::Type::SingletonType)
             ic = env[:self].val
           else
-            ic = env[:self].class
+            ic = env[:self].klass
           end
         else
           ic = Object


### PR DESCRIPTION
This fixes the following error:

```ruby
require "rdl"

class Foo
  extend RDL::Annotate

  class Bar
    C = 1
  end

  type "() -> %any", typecheck: :now
  def foo
    Bar::C
  end
end
```

```
/home/mame/work/rdl/lib/rdl/typecheck.rb:628:in `const_get': uninitialized constant RDL::Type::NominalType::Bar (NameError)
```