### PR TITLE
Fixes for rails: Allow UUID/JSONB column types, ensure anonymous_class is defined

### DIFF
--- a/lib/types/rails/_helpers.rb
+++ b/lib/types/rails/_helpers.rb
@@ -9,7 +9,7 @@ class RDL::Rails
   # returns a String containing an RDL type
   def self.column_to_rdl(rails_type)
     case rails_type
-    when :string, :text, :binary, :uuid
+    when :string, :text, :binary, :uuid, :jsonb
       return 'String'
     when :integer
       return 'Fixnum'

--- a/lib/types/rails/_helpers.rb
+++ b/lib/types/rails/_helpers.rb
@@ -9,7 +9,7 @@ class RDL::Rails
   # returns a String containing an RDL type
   def self.column_to_rdl(rails_type)
     case rails_type
-    when :string, :text, :binary
+    when :string, :text, :binary, :uuid
       return 'String'
     when :integer
       return 'Fixnum'

--- a/lib/types/rails/_helpers.rb
+++ b/lib/types/rails/_helpers.rb
@@ -2,6 +2,7 @@
 # null allowed
 
 RDL.type_alias '%symstr', 'Symbol or String'
+RDL.type_alias '%jsonb', 'String or Float or Integer or Hash or Array or %bool' 
 
 class RDL::Rails
 
@@ -11,6 +12,8 @@ class RDL::Rails
     case rails_type
     when :string, :text, :binary, :uuid, :jsonb
       return 'String'
+    when :jsonb
+      return '%jsonb'
     when :integer
       return 'Fixnum'
     when :float

--- a/lib/types/rails/active_record/associations.rb
+++ b/lib/types/rails/active_record/associations.rb
@@ -118,7 +118,7 @@ module ActiveRecord::Associations::ClassMethods
      assoc_type = '%any' # type is data-driven, can't determine statically
     elsif class_name
      assoc_type = class_name.to_s.classify
-    elsif anonymous_class # not sure this has anonymou_class
+    elsif defined? anonymous_class # not sure this has anonymous_class
      assoc_type = anonymous_class.to_s.classify
     else
      assoc_type = name.to_s.classify # camelize?


### PR DESCRIPTION
- Check for anonymous_class definition before attempting to use it
- Ensure UUID column types are mapped to strings when using UUID PKs.
- Add JSONB -> %jsobn type mapping.

The only thing I'm uncertain of is JSONB type mapping.  As it's JSONB this should be parsed; the resulting datatype could be any primitive matching `String or Integer or Float or Hash or Array or %bool`.  I've added a type map for `%jsonb`, though I'm not sure if this is correct.