### PR TITLE
CI: Drop sudo: false directive, add 2.5.5, 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ rvm:
   - 2.3.4
   - 2.4.0
   - 2.4.1
-sudo: false
+  - 2.5.5
+  - 2.6.2
+
 notifications:
   email:
     recipients:

--- a/lib/rdl/typecheck.rb
+++ b/lib/rdl/typecheck.rb
@@ -620,7 +620,7 @@ module RDL::Typecheck
           if env[:self].is_a?(RDL::Type::SingletonType)
             ic = env[:self].val
           else
-            ic = env[:self].klass
+            ic = env[:self].class
           end
         else
           ic = Object

--- a/lib/rdl/typecheck.rb
+++ b/lib/rdl/typecheck.rb
@@ -620,7 +620,7 @@ module RDL::Typecheck
           if env[:self].is_a?(RDL::Type::SingletonType)
             ic = env[:self].val
           else
-            ic = env[:self].class
+            ic = env[:self].klass
           end
         else
           ic = Object


### PR DESCRIPTION
This PR removes an unused directive from the CI configuration: See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Also adds:

- 2.5.5
- 2.6.2