### PR TITLE
Small fix in matching_classes in heuristics.rb + logging for the struct_to_nominal heuristic

### DIFF
--- a/lib/rdl/heuristics.rb
+++ b/lib/rdl/heuristics.rb
@@ -17,10 +17,7 @@ class RDL::Heuristic
     return @meth_cache[meth_names] if @meth_cache.key? meth_names
     RDL::Logging.log :heuristics, :debug, "Checking matching classes for #{meth_names}"
 
-    matching_classes = ObjectSpace.each_object(Class).select { |c|
-      class_methods = c.instance_methods | RDL::Globals.info.get_methods_from_class(c.to_s)
-      (meth_names - class_methods).empty? } ## will only be empty if meth_names is a subset of c.instance_methods
-    matching_classes += ObjectSpace.each_object(Module).select { |c|
+    matching_classes = ObjectSpace.each_object(Module).select { |c|
       class_methods = c.instance_methods | RDL::Globals.info.get_methods_from_class(c.to_s)
       (meth_names - class_methods).empty? } ## will only be empty if meth_names is a subset of c.instance_methods
 
@@ -41,6 +38,10 @@ class RDL::Heuristic
     ## TODO: special handling for arrays/hashes/generics?
     ## TODO: special handling for Rails models? see Bree's `active_record_match?` method
     #raise "No matching classes found for structural types with methods #{meth_names}." if matching_classes.empty?
+    RDL::Logging.log :heuristics,
+                     :debug,
+                     "Struct_to_nominal heuristsic for %s in method %s:%s yields %d matching classes with methods: %s" %
+                         [var_type.name, var_type.cls, var_type.meth, matching_classes.size, meth_names*","]
     return if matching_classes.size > 10 ## in this case, just keep the struct types
     nom_sing_types = matching_classes.map { |c| if c.singleton_class? then RDL::Type::SingletonType.new(RDL::Util.singleton_class_to_class(c)) else RDL::Type::NominalType.new(c) end }
     union = RDL::Type::UnionType.new(*nom_sing_types).canonical


### PR DESCRIPTION
Removed iterating over the Class `ObjectSpace` in `matching_classes` method since `ObjectSpace.each_object(Class)` generates a subset of `ObjectSpace.each_object(Module)`. 

Added debug-level logging to `struct_to_nominal` method in the same file.