### PR TITLE
Matching classes speed-up and more logging

### DIFF
--- a/lib/rdl/heuristics.rb
+++ b/lib/rdl/heuristics.rb
@@ -4,6 +4,15 @@ class RDL::Heuristic
 
   @meth_cache = {}
 
+  @meth_to_cls_map = Hash.new {|hash, m| hash[m] = Set.new}  # maps a method to a set of classes with that method
+
+  def self.init_meth_to_cls  # to be called before the first call to struct_to_nominal
+    ObjectSpace.each_object(Module).each do |c|
+      class_methods = c.instance_methods | RDL::Globals.info.get_methods_from_class(c.to_s)
+      class_methods.each {|m| @meth_to_cls_map[m] = @meth_to_cls_map[m].add(c)}
+    end
+  end
+
   def self.add(name, &blk)
     raise RuntimeError, "Expected heuristic name to be Symbol, given #{name}." unless name.is_a? Symbol
     raise RuntimeError, "Expected block to be provided for heuristic." if blk.nil?
@@ -14,13 +23,28 @@ class RDL::Heuristic
     meth_names.delete(:initialize)
     meth_names.delete(:new)
 
-    return @meth_cache[meth_names] if @meth_cache.key? meth_names
-    RDL::Logging.log :heuristics, :debug, "Checking matching classes for #{meth_names}"
+    # meth_names = meth_names.sort  # otherwise cache works almost only when meth_names.size == 1
+    if @meth_cache.key? meth_names
+      RDL::Logging.log :heuristic, :trace, "Cache used to find %d matching classes" % @meth_cache[meth_names].size
+      return @meth_cache[meth_names]
+    end
 
-    matching_classes = ObjectSpace.each_object(Module).select { |c|
-      class_methods = c.instance_methods | RDL::Globals.info.get_methods_from_class(c.to_s)
-      (meth_names - class_methods).empty? } ## will only be empty if meth_names is a subset of c.instance_methods
+    init_meth_to_cls if @meth_to_cls_map.empty?  # initialize @meth_to_cls on first call to matching_classes
 
+    # matching_classes = meth_names.map {|m| @meth_to_cls_map[m]}.reduce(:&).to_a  # faster but does not allow debugging
+    matching_classes = @meth_to_cls_map[meth_names[0]]
+    meth_names[1..-1].each_with_index do |m, index|
+      tmp = matching_classes.intersection(@meth_to_cls_map[m])
+      if tmp.empty? && !matching_classes.empty?
+        RDL::Logging.log :heuristic, :trace,
+                         "Found %d matching classes for methods: %s, but none of these classes have method %s" %
+                             [matching_classes.size, meth_names[0..index] * ", ", m]
+      end
+      matching_classes = tmp
+    end
+
+
+    RDL::Logging.log :heuristic, :trace, "Overall, found %d matching classes" % matching_classes.size
     @meth_cache[meth_names] = matching_classes
     matching_classes
   end
@@ -31,20 +55,21 @@ class RDL::Heuristic
     return unless var_type.ubounds.any? { |t, loc| t.is_a?(RDL::Type::StructuralType) } ## upper bounds must include struct type(s)
     struct_types = var_type.ubounds.select { |t, loc| t.is_a?(RDL::Type::StructuralType) }
     struct_types.map! { |t, loc| t }
+    RDL::Logging.log :heuristic, :trace, "Found %d upper bounds of structural type" % struct_types.size
     return if struct_types.empty?
     meth_names = struct_types.map { |st| st.methods.keys }.flatten.uniq
+    RDL::Logging.log :heuristic, :trace, "Corresponding methods are: %s" % (meth_names*", ")
     matching_classes = matching_classes(meth_names)
     matching_classes.reject! { |c| c.to_s.start_with?("#<Class") || /[^:]*::[a-z]/.match?(c.to_s) || c.to_s.include?("ARGF") } ## weird few constants where :: is followed by a lowecase letter... it's not a class and I can't find anything written about it.
+    RDL::Logging.log :heuristic, :trace, "Throwing out 'weird constants' leaves %d matching classes" % matching_classes.size
     ## TODO: special handling for arrays/hashes/generics?
     ## TODO: special handling for Rails models? see Bree's `active_record_match?` method
     #raise "No matching classes found for structural types with methods #{meth_names}." if matching_classes.empty?
-    RDL::Logging.log :heuristics,
-                     :debug,
-                     "Struct_to_nominal heuristsic for %s in method %s:%s yields %d matching classes with methods: %s" %
-                         [var_type.name, var_type.cls, var_type.meth, matching_classes.size, meth_names*","]
     return if matching_classes.size > 10 ## in this case, just keep the struct types
     nom_sing_types = matching_classes.map { |c| if c.singleton_class? then RDL::Type::SingletonType.new(RDL::Util.singleton_class_to_class(c)) else RDL::Type::NominalType.new(c) end }
+    RDL::Logging.log :heuristic, :trace, "These are: %s" % (nom_sing_types*", ")
     union = RDL::Type::UnionType.new(*nom_sing_types).canonical
+    RDL::Logging.log :heuristic, :trace, "The union of which is canonicalized to %s" % union
     #struct_types.each { |st| var_type.ubounds.delete_if { |s, loc| s.equal?(st) } } ## remove struct types from upper bounds
 
 

--- a/lib/rdl/heuristics.rb
+++ b/lib/rdl/heuristics.rb
@@ -58,6 +58,9 @@ class RDL::Heuristic
     RDL::Logging.log :heuristic, :trace, "Found %d upper bounds of structural type" % struct_types.size
     return if struct_types.empty?
     meth_names = struct_types.map { |st| st.methods.keys }.flatten.uniq
+    meth_names.delete(:initialize)
+    meth_names.delete(:new)
+    return if meth_names.empty?
     RDL::Logging.log :heuristic, :trace, "Corresponding methods are: %s" % (meth_names*", ")
     matching_classes = matching_classes(meth_names)
     matching_classes.reject! { |c| c.to_s.start_with?("#<Class") || /[^:]*::[a-z]/.match?(c.to_s) || c.to_s.include?("ARGF") } ## weird few constants where :: is followed by a lowecase letter... it's not a class and I can't find anything written about it.


### PR DESCRIPTION
More extensive logging added to `struct_to_nominal` and `matching_classes` (now on `trace` level).

Matching is now done by iterating over methods in question and intersecting the sets of classes for which these methods are defined, which significantly speeds up the process. 

For this to work, `init_meth_to_cls` builds a map from methods to classes on the first call to matching_classes.