### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+title: "RDL: Types, typechecking, and contracts for Ruby."
+version: 2.1.0
+message: "If you use this software, please cite it using the metadata from this file."
+authors:
+- family-names: "Foster"
+  given-names: "Jeffrey"
+  website: "http://www.cs.tufts.edu/~jfoster/"
+- family-names: "Ren"
+  given-names: "Brianna"
+  website: "https://briannren.github.io/"
+- family-names: "Strickland"
+  given-names: "Stephen"
+  website: "https://www.cs.umd.edu/~sstrickl/"
+- family-names: "Yu"
+  given-names: "Alexander"
+- family-names: "Kazerounian"
+  given-names: "Milod"
+- family-names: "Guria"
+  given-names: "Sankha Narayan"
+  website: "https://sankhs.com/"
+date-released: 2017-06-14
+url: "https://github.com/tupl-tufts/rdl"
+license: BSD-3-Clause


### PR DESCRIPTION
[Last year](https://twitter.com/natfriedman/status/1420122675813441540) GitHub introduced support for [`CITATION.cff`](https://citation-file-format.github.io/), which makes it easy to cite a GitHub repository. 

Since this repository was already cited by at least three papers[^1][^2][^3] (found with a quick [google scholar search](https://scholar.google.com/scholar?hl=en&as_sdt=0%2C5&q=github.com%2Ftupl-tufts%2Frdl%2F&btnG=)), I thought that for future research it might be helpful to include a `CITATION.cff` file.

## Questions
I created the file to the best of my knowlege but there are some fields where I wasn't sure.

### Personal websites
In `README.md` some of the authors added personal websites, I included them in the file, but I am not sure if they are important in a file that will be used for scientific research.

### Release date
In the papers InferDL[^1] and SimTyper[^2], this repository is cited as beeing released in 2018. However, I cannot figure out why. Both the repository as the last release were created before 2018. I am very likely missing something here.

For now, I have included the date of the last release as the release date. This wasn't in 2018 as cited in those papers but I cannot figure out a specific day in 2018 that would be make sense and the file format unfortunately needs a specific day.

[^1]: Milod Kazerounian, Brianna M. Ren, and Jeffrey S. Foster. 2020. Sound, heuristic type annotation inference for Ruby. Proceedings of the 16th ACM SIGPLAN International Symposium on Dynamic Languages. Association for Computing Machinery, New York, NY, USA, 112–125. https://doi.org/10.1145/3426422.3426985
[^2]: Milod Kazerounian, Jeffrey S. Foster, and Bonan Min. 2021. SimTyper: sound type inference for Ruby using type equality prediction. Proc. ACM Program. Lang. 5, OOPSLA, Article 106 (October 2021), 27 pages. https://doi.org/10.1145/3485483
[^3]: Sankha Narayan Guria, Jeffrey S. Foster, and David Van Horn. 2021. RbSyn: type- and effect-guided program synthesis. In Proceedings of the 42nd ACM SIGPLAN International Conference on Programming Language Design and Implementation (PLDI 2021). Association for Computing Machinery, New York, NY, USA, 344–358. https://doi.org/10.1145/3453483.3454048

      

