### PR TITLE
[Ruby 3] Get RDL running on Ruby 3

### DIFF
--- a/lib/rdl/contracts/proc.rb
+++ b/lib/rdl/contracts/proc.rb
@@ -9,11 +9,11 @@ module RDL::Contract
 
 
     def wrap(slf, &blk)
-      Proc.new {|*v, &other_blk|
-        @pre_cond.check(slf, *v, &other_blk)
-        tmp = other_blk ? slf.instance_exec(*v, other_blk, &blk) : slf.instance_exec(*v, &blk) # TODO fix blk
+      Proc.new {|*v, **kv, &other_blk|
+        @pre_cond.check(slf, *v, **kv, &other_blk)
+        tmp = other_blk ? slf.instance_exec(*v, **kv, &other_blk) : slf.instance_exec(*v, **kv, &blk) # TODO fix blk
         # tmp = blk.call(*v, &other_blk) # TODO: Instance eval with self
-        @post_cond.check(slf, tmp, *v, &other_blk)
+        @post_cond.check(slf, tmp, *v, **kv, &other_blk)
         tmp
       }
     end

--- a/lib/rdl/typecheck.rb
+++ b/lib/rdl/typecheck.rb
@@ -2181,7 +2181,7 @@ module Parser
           raise IndexError, "The range #{range} is outside the bounds of the source of size #{@source_buffer.source.size}"
         end
         dummy_range = Parser::Source::Range.new(@source_buffer, range.begin_pos - offset, range.end_pos - offset)
-        action = TreeRewriter::Action.new(dummy_range, @enforcer, attributes)
+        action = TreeRewriter::Action.new(dummy_range, @enforcer, **attributes)
         @action_root = @action_root.combine(action)
         self
       end

--- a/lib/rdl/util.rb
+++ b/lib/rdl/util.rb
@@ -91,6 +91,7 @@ class RDL::Util
 
   def self.silent_warnings
     old_stderr = $stderr
+    require "stringio"
     $stderr = StringIO.new
     yield
   ensure

--- a/lib/rdl/wrap.rb
+++ b/lib/rdl/wrap.rb
@@ -144,7 +144,7 @@ RUBY
     else
       raise ArgumentError, "Invalid arguments to `type`"
     end
-    raise ArgumentError, "Excepting method type, got #{type.class} instead" if type.class != RDL::Type::MethodType
+    raise ArgumentError, "Expecting method type, got #{type.class} instead" if type.class != RDL::Type::MethodType
 #    meth = :initialize if meth && slf && meth.to_sym == :new  # actually wrap constructor
     klass = RDL::Util.add_singleton_marker(klass) if slf
     return [klass, meth, type]

--- a/test/test_lib_types.rb
+++ b/test/test_lib_types.rb
@@ -81,9 +81,9 @@ class TestStdlibTypes < Minitest::Test
       BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
       BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
 
-      BigDecimal.new(BigDecimal('Infinity'))
-      BigDecimal.new(BigDecimal('-Infinity'))
-      BigDecimal(BigDecimal.new('NaN'))
+      BigDecimal(BigDecimal('Infinity'))
+      BigDecimal(BigDecimal('-Infinity'))
+      BigDecimal(BigDecimal('NaN'))
     end
     BigDecimal.save_limit do
       BigDecimal.limit(200)
@@ -106,10 +106,10 @@ class TestStdlibTypes < Minitest::Test
     # From the Ruby stdlib documentation
     BigMath.E(10)
     BigMath.PI(10)
-    BigMath.atan(BigDecimal.new('-1'), 16)
+    BigMath.atan(BigDecimal('-1'), 16)
     BigMath.cos(BigMath.PI(4), 16)
     BigMath.sin(BigMath.PI(5)/4, 5)
-    BigMath.sqrt(BigDecimal.new('2'), 16)
+    BigMath.sqrt(BigDecimal('2'), 16)
   end
 
   def test_class

--- a/test/test_typecheck.rb
+++ b/test/test_typecheck.rb
@@ -1819,7 +1819,7 @@ class TestTypecheck < Minitest::Test
         when :b
         end
       end
-      type(:foo, '(Symbol) -> NilClass', {:typecheck => :call})
+      type(:foo, '(Symbol) -> NilClass', typecheck: :call)
     end
 
     assert_nil TestTypecheck::A5.new.foo(:a)


### PR DESCRIPTION
Ruby 3 changed positional and keyword arguments behavior. Read more [here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

This commit fixes the errors in RDL due to this change and get it to passing all tests. Another test has been changed to reflect the new BigDecimal API.